### PR TITLE
Fix index setting and moving, lock track reads

### DIFF
--- a/RedBookPlayer/Player.cs
+++ b/RedBookPlayer/Player.cs
@@ -430,21 +430,17 @@ namespace RedBookPlayer
                 return;
             }
 
-            if (++CurrentIndex > Image.Tracks[CurrentTrack].Indexes.Keys.Max())
+            if (CurrentIndex + 1 > Image.Tracks[CurrentTrack].Indexes.Keys.Max())
             {
                 if (changeTrack)
                 {
                     NextTrack();
-                    CurrentSector = (ulong)Image.Tracks[CurrentTrack].Indexes[1];
-                }
-                else
-                {
-                    CurrentSector = (ulong)Image.Tracks[CurrentTrack].Indexes[--CurrentIndex];
+                    CurrentSector = (ulong)Image.Tracks[CurrentTrack].Indexes.Values.Min();
                 }
             }
             else
             {
-                CurrentSector = (ulong)Image.Tracks[CurrentTrack].Indexes[CurrentIndex];
+                CurrentSector = (ulong)Image.Tracks[CurrentTrack].Indexes[++CurrentIndex];
             }
         }
 
@@ -455,21 +451,17 @@ namespace RedBookPlayer
                 return;
             }
 
-            if (CurrentIndex <= 1 || --CurrentIndex < Image.Tracks[CurrentTrack].Indexes.Keys.Min())
+            if (CurrentIndex - 1 < Image.Tracks[CurrentTrack].Indexes.Keys.Min())
             {
                 if (changeTrack)
                 {
                     PreviousTrack();
                     CurrentSector = (ulong)Image.Tracks[CurrentTrack].Indexes.Values.Max();
                 }
-                else
-                {
-                    CurrentSector = (ulong)Image.Tracks[CurrentTrack].Indexes[1];
-                }
             }
             else
             {
-                CurrentSector = (ulong)Image.Tracks[CurrentTrack].Indexes[CurrentIndex];
+                CurrentSector = (ulong)Image.Tracks[CurrentTrack].Indexes[--CurrentIndex];
             }
         }
 


### PR DESCRIPTION
- Replaces call to `GetEnumerator().Current`, which was always returning `default(ushort)` for the index keys, with a `.Min()` in order to find the first index in the track.
- Adds actual locking around all track reads, as once the above was fixed, changing tracks had a high probability of running into cache repeats in Aaru code (concurrent invocations of non-concurrent-safe code)
- Ensure index is valid before attempting to increment or decrement the `CurrentIndex` or `CurrentTrack`

https://github.com/aaru-dps/RedBookPlayer/pull/3/commits/09f14810dd1d7f4db27819336819650d2cb0986a and https://github.com/aaru-dps/RedBookPlayer/pull/3/commits/df3d90a5309e1003f7b1eeef12c7412f0b398c61 fixes #2 
https://github.com/aaru-dps/RedBookPlayer/pull/3/commits/bc645c21f0f515b534b6b97eba118c62e5d0fae1 fixes #4 